### PR TITLE
docs: note TypeScript requirement for bundler resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ npm run lint
 npm run format
 ```
 
+> **Nota:** Esta configuración utiliza `moduleResolution: bundler`, por lo que se requiere TypeScript 5.0 o superior y un empaquetador moderno (por ejemplo, Metro, Vite o Webpack 5).
+
 ## Estructura del Proyecto
 
 ```

--- a/autodocops-ui/tsconfig.json
+++ b/autodocops-ui/tsconfig.json
@@ -11,6 +11,7 @@
     "lib": ["ES2015", "ES2017", "ES2018", "DOM"],
     "target": "ES2015",
     "jsx": "react-jsx",
+    // Requires TypeScript 5.0+ and a modern bundler.
     "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true


### PR DESCRIPTION
## Summary
- document that bundler module resolution requires TypeScript 5.0+
- clarify TypeScript and bundler requirement in README

## Testing
- `npm run type-check`
- `npm run lint` *(warn: '_err' is defined but never used)*

------
https://chatgpt.com/codex/tasks/task_e_68916d6e480c8324bb78dbc73b3a98a2