### PR TITLE
feat(trpc): add minimal AppRouter typing

### DIFF
--- a/autodocops-ui/src/lib/trpc.ts
+++ b/autodocops-ui/src/lib/trpc.ts
@@ -1,5 +1,6 @@
 import { createTRPCReact } from '@trpc/react-query';
 import { createTRPCClient, httpBatchLink } from '@trpc/client';
+import type { AnyRouter } from '@trpc/server';
 import { useSession } from '../stores/useSession';
 
 // Types
@@ -45,10 +46,31 @@ export interface ChatResponse {
   timestamp: string;
 }
 
-// Define AppRouter type interface (this would come from your backend)
-// In a real application, this would be imported from your tRPC backend
-// Using 'any' temporarily until the backend router is properly implemented
-export type AppRouter = any;
+// Minimal AppRouter interface describing expected procedures
+export interface AppRouter extends AnyRouter {
+  auth: {
+    login: {
+      input: LoginInput;
+      output: AuthResponse;
+    };
+  };
+  projects: {
+    list: {
+      input: void;
+      output: Project[];
+    };
+    create: {
+      input: CreateProjectInput;
+      output: Project;
+    };
+  };
+  chat: {
+    sendMessage: {
+      input: ChatMessage;
+      output: ChatResponse;
+    };
+  };
+}
 
 // Create tRPC React hooks with proper typing
 export const trpc = createTRPCReact<AppRouter>();
@@ -57,7 +79,7 @@ export const trpc = createTRPCReact<AppRouter>();
 export const createClient = () => {
   const apiUrl = 'http://localhost:3000/trpc'; // Default to localhost for development
     
-  return createTRPCClient({
+  return createTRPCClient<AppRouter>({
     links: [
       httpBatchLink({
         url: apiUrl,


### PR DESCRIPTION
## Summary
- define a minimal `AppRouter` interface capturing expected auth, project, and chat procedures
- use `AppRouter` generics in `createTRPCReact` and `createTRPCClient` for stronger typing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68916d6bcd9c8324a6e09b0eca4e9ad9