### PR TITLE
feat: use expo API URL env variable

### DIFF
--- a/autodocops-ui/src/lib/trpc.ts
+++ b/autodocops-ui/src/lib/trpc.ts
@@ -1,5 +1,6 @@
 import { createTRPCReact } from '@trpc/react-query';
 import { createTRPCClient, httpBatchLink } from '@trpc/client';
+import Constants from 'expo-constants';
 import { useSession } from '../stores/useSession';
 
 // Types
@@ -55,8 +56,11 @@ export const trpc = createTRPCReact<AppRouter>();
 
 // tRPC client configuration
 export const createClient = () => {
-  const apiUrl = 'http://localhost:3000/trpc'; // Default to localhost for development
-    
+  const apiUrl =
+    process.env.EXPO_PUBLIC_API_URL ??
+    Constants.expoConfig?.extra?.apiUrl ??
+    'http://localhost:3000/trpc';
+
   return createTRPCClient({
     links: [
       httpBatchLink({


### PR DESCRIPTION
## Summary
- use Expo's environment variables or config to derive the TRPC API URL, with a local fallback

## Testing
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68917abc717083249f2f21d1128a80a5