### PR TITLE
docs: note TypeScript 5 and bundler requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ autodocops-ui/
 
 ## Configuración de Desarrollo
 
+Este proyecto requiere **TypeScript 5.0+** y un bundler moderno compatible con `moduleResolution: "bundler"`.
+
 ### Variables de Entorno
 
 Crear archivo `.env` basado en `.env.example`:

--- a/autodocops-ui/tsconfig.json
+++ b/autodocops-ui/tsconfig.json
@@ -11,7 +11,7 @@
     "lib": ["ES2015", "ES2017", "ES2018", "DOM"],
     "target": "ES2015",
     "jsx": "react-jsx",
-    "moduleResolution": "bundler",
+    "moduleResolution": "bundler", // Requiere TypeScript 5.0+ y un bundler moderno
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true
   }


### PR DESCRIPTION
## Summary
- document that moduleResolution 'bundler' needs TypeScript 5.0+ and a modern bundler
- highlight the same TypeScript/bundler requirement in README for contributors

## Testing
- `npm run lint` *(warning: '_err' is defined but never used)*
- `npm run type-check`
- `npm run format:check` *(warn: code style issues found in 28 files)*

------
https://chatgpt.com/codex/tasks/task_e_68917ac1adb88324992b923c81900172